### PR TITLE
chore: 현행화하기 전까지 현재 기준으로 2022년으로 설정합니다

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,129 @@
-# 사회적 추모 프로젝트
+사회적 추모 (Online Memorial) 
+-----------------------------
+
+> 잊혀진 산업재해 희생자들을 추모하는 공간
+
+[online-memorial.codefor.kr](https://online-memorial.codefor.kr) 서비스의 프론트엔드 저장소입니다.
+
+## 프로젝트 개요
+
+본 프로젝트는 산업재해 희생자들을 기억하고 추모하기 위한 웹 서비스의 클라이언트 애플리케이션입니다. 백엔드 API와 연동하여 산업재해 통계, 추모 게시글, 관련 소식 등을 제공합니다.
+
+- **백엔드 저장소**: [wagurano/candlelight](https://github.com/wagurano/candlelight) (Rails 기반 API 서버)
+- **배포 주소**: [https://code-for-korea.github.io/online-memorial](https://code-for-korea.github.io/online-memorial)
+- 서버 이전 작업 진행중입니다
+
+## 기술 스택
+
+- **프레임워크**: React 18
+- **언어**: TypeScript 4.7+
+- **빌드 도구**: Create React App
+- **HTTP 클라이언트**: Axios
+- **차트 라이브러리**: Chart.js, react-chartjs-2
+- **UI 개발 환경**: Storybook
+- **배포**: GitHub Pages
+
+## 시작하기
+
+### 사전 요구사항
+
+- Node.js 16+
+- npm 또는 yarn
+
+### 설치
+
+```bash
+cd client
+npm install
+```
+
+### 개발 서버 실행
+
+```bash
+npm start
+```
+
+브라우저에서 `http://localhost:3000`으로 접속합니다.
+
+### 빌드
+
+```bash
+npm run build
+```
+
+`build/` 디렉토리에 프로덕션 빌드가 생성됩니다.
+
+### Storybook 실행
+
+```bash
+npm run storybook
+```
+
+`http://localhost:6006`에서 컴포넌트 문서를 확인할 수 있습니다.
+
+### 배포
+
+```bash
+npm run deploy
+```
+
+GitHub Pages로 배포됩니다. (`gh-pages` 브랜치)
+
+## 프로젝트 구조
+
+```
+client/
+├── public/              # 정적 자산 (favicon, index.html 등)
+├── src/
+│   ├── api/             # Axios 인스턴스 및 API 설정
+│   ├── components/      # 재사용 가능한 UI 컴포넌트
+│   │   ├── animation/   # 애니메이션 관련 컴포넌트
+│   │   ├── carousel/    # 캐러셀 컴포넌트
+│   │   ├── common/      # 공용 컴포넌트
+│   │   ├── dataTable/   # 데이터 테이블 컴포넌트
+│   │   ├── modal/       # 모달 컴포넌트
+│   │   ├── newsCard/    # 뉴스/소식 카드 컴포넌트
+│   │   ├── pagination/  # 페이지네이션 컴포넌트
+│   │   └── post/        # 게시글 관련 컴포넌트
+│   ├── config/          # 상수 및 설정
+│   ├── services/        # API 호출 비즈니스 로직
+│   ├── style/           # 전역 스타일
+│   ├── views/           # 페이지 단위 뷰 컴포넌트
+│   │   ├── Layout/              # 전체 레이아웃
+│   │   ├── MemorialAnimation/   # 추모 애니메이션 영역
+│   │   └── MemorialMainContent/ # 메인 콘텐츠 영역
+│   ├── App.tsx          # 루트 컴포넌트
+│   └── index.tsx        # 엔트리 포인트
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## 주요 기능
+
+- **추모 애니메이션**: 희생자들을 기리는 시각적 추모 공간
+- **산업재해 통계**: 연도별 사망/부상 통계, 요일별/시간대별 통계 차트 제공
+- **재난 정보 조회**: 산업재해 관련 재난 정보 데이터 테이블 및 페이지네이션
+- **추모 게시글**: 추모 글 작성 및 목록 조회
+- **관련 소식**: 산업재해 및 노동 관련 이야기(뉴스) 제공
+
+## API 연동
+
+백엔드 API 서버(`https://candlelight-wdkq.onrender.com`)와 통신합니다.
+
+주요 엔드포인트:
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| GET | `/stats/year/:year` | 연도별 통계 조회 |
+| GET | `/posts` | 추모 게시글 목록 |
+| POST | `/posts` | 추모 게시글 작성 |
+| GET | `/disasters` | 재난 정보 목록 |
+| GET | `/stories` | 관련 소식 목록 |
+
+자세한 API 문서는 [Swagger UI](https://candlelight-wdkq.onrender.com/api-docs)에서 확인할 수 있습니다.
+> 서버 이전 작업중입니다.
+
+## 라이선스
+
+본 프로젝트는 [Code for Korea](https://codefor.kr) 커뮤니티와 함께 합니다.

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
 
 export const Axios = axios.create({
-    baseURL: "https://candle-c4k.herokuapp.com"
+    baseURL: "https://candlelight-wdkq.onrender.com"
 })

--- a/client/src/services/data.service.ts
+++ b/client/src/services/data.service.ts
@@ -14,15 +14,15 @@ export type PercentageStatistic = "day" | "time"
 export default class DataService {
     static async getTotalCount(victimStatus: VictimStatus, year: number): Promise<number | null> {
         const response = await Axios.get(`/stats/year/${year}`);
-        if (response.status === 200) {
-            return response.data[victimStatus];
+        if (response.status === 200 && response.data) {
+            return response.data[victimStatus] ?? null;
         }
         return null;
     }
 
     static async getStatisticByTime(year: number): Promise<StatisticDataByDay | null> {
         const response = await Axios.get(`/stats/year/${year}`);
-        if (response.status === 200) {
+        if (response.status === 200 && response.data) {
             return Object.entries(response.data)
                 .filter(([key, _]) => key.includes("hour"))
                 .map(([key, value]) => [parseInt(key.replace('hour_', '')), value])
@@ -34,7 +34,7 @@ export default class DataService {
 
     static async getStatisticByDay(year: number): Promise<StatisticDataByDay | null> {
         const response = await Axios.get(`/stats/year/${year}`);
-        if (response.status === 200) {
+        if (response.status === 200 && response.data) {
             return Object.entries(response.data)
                 .filter(([key, _]) => key.includes("week"))
                 .map(([key, value]) => [parseInt(key.replace('week_', '')), value])

--- a/client/src/stories/Divider.stories.tsx
+++ b/client/src/stories/Divider.stories.tsx
@@ -11,7 +11,9 @@ const Template: ComponentStory<typeof Divider> = (args: DividerProps) => <Divide
 
 export const TitleOne = Template.bind({})
 TitleOne.args = {
-    title: `사회적 추모 아카이브 ${new Date(Date.now()).getFullYear()}`
+    // NOTE: 데이터 현행화하기 전까지 2022년으로 설정합니다
+    // title: `사회적 추모 아카이브 ${new Date(Date.now()).getFullYear()}`
+    title: `사회적 추모 아카이브 ${2022}`
 }
 
 export const TitleTwo = Template.bind({})

--- a/client/src/views/MemorialAnimation/index.tsx
+++ b/client/src/views/MemorialAnimation/index.tsx
@@ -14,7 +14,9 @@ export type MemorialAnimationProps = {
     year?: number;
 }
 
-const MemorialAnimation: React.FC<MemorialAnimationProps> = ({ onPostSubmit, year = new Date(Date.now()).getFullYear() }) => {
+// NOTE: 현행화하기 전까지 2022년으로 설정합니다
+// const MemorialAnimation: React.FC<MemorialAnimationProps> = ({ onPostSubmit, year = new Date(Date.now()).getFullYear() }) => {
+const MemorialAnimation: React.FC<MemorialAnimationProps> = ({ onPostSubmit, year = 2022 }) => {
 
     const [showAddPostModal, setShowAddPostModal] = useState(false);
     const [deathCount, setDeathCount] = useState<number>(getCachedDeathCount());
@@ -23,7 +25,9 @@ const MemorialAnimation: React.FC<MemorialAnimationProps> = ({ onPostSubmit, yea
 
 
     const initializeDeathCount = async () => {
-        const data = await DataService.getTotalCount("death", new Date(Date.now()).getFullYear());
+        // NOTE: 현행화하기 전까지 2022년으로 설정합니다
+        // const data = await DataService.getTotalCount("death", new Date(Date.now()).getFullYear());
+        const data = await DataService.getTotalCount("death", 2022);
         if (data !== null) {
             setDeathCount(data);
             setCachedDeathCount(data);

--- a/client/src/views/MemorialMainContent/MemorialInfomations/MemorialStatistics/Cards/StatisticByDayCard/index.tsx
+++ b/client/src/views/MemorialMainContent/MemorialInfomations/MemorialStatistics/Cards/StatisticByDayCard/index.tsx
@@ -22,7 +22,9 @@ const StatisticByDayCard: React.FC<StatisticByDayCardProps> = () => {
 
     const initializeStatisticByDay = useCallback(async () => {
         const data = await DataService.getStatisticByDay(
-            new Date(Date.now()).getFullYear()
+            // NOTE: 현행화하기 전까지 2022년으로 설정합니다
+            // new Date(Date.now()).getFullYear()
+            2022
         );
         if (data !== null) {
             setStatisticByDay(data);

--- a/client/src/views/MemorialMainContent/MemorialInfomations/MemorialStatistics/Cards/StatisticByTimeCard/index.tsx
+++ b/client/src/views/MemorialMainContent/MemorialInfomations/MemorialStatistics/Cards/StatisticByTimeCard/index.tsx
@@ -24,7 +24,9 @@ const StatisticByTimeCard: React.FC<StatisticByTimeCardProps> = () => {
 
     const initializeStatisticByTime = useCallback(async () => {
         const data = await DataService.getStatisticByTime(
-            new Date(Date.now()).getFullYear()
+            // NOTE: 현행화하기 전까지 2022년으로 설정합니다
+            // new Date(Date.now()).getFullYear()
+            2022
         );
         if (data !== null) {
             const startFromSixteen = [...data.slice(data.length - 6, data.length), ...data.slice(0, data.length - 6)];

--- a/client/src/views/MemorialMainContent/MemorialInfomations/MemorialStatistics/Cards/TotalStatisticCard/index.tsx
+++ b/client/src/views/MemorialMainContent/MemorialInfomations/MemorialStatistics/Cards/TotalStatisticCard/index.tsx
@@ -18,14 +18,18 @@ const TotalStatisticCard: React.FC<TotalStatisticCardProps> = () => {
     const subtitle = "전체 산업재해 사망사고"
 
     const updateDeadCount = useCallback(async () => {
-        const data = await DataService.getTotalCount("death", new Date(Date.now()).getFullYear());
+        // NOTE: 현행화하기 전까지 2022년으로 설정합니다
+        // const data = await DataService.getTotalCount("death", new Date(Date.now()).getFullYear());
+        const data = await DataService.getTotalCount("death", 2022);
         if (data !== null) {
             setDead(data);
         }
     }, [])
 
     const updateInjuredCount = useCallback(async () => {
-        const data = await DataService.getTotalCount("injury", new Date(Date.now()).getFullYear());
+        // NOTE: 현행화하기 전까지 2022년으로 설정합니다
+        // const data = await DataService.getTotalCount("injury", new Date(Date.now()).getFullYear());
+        const data = await DataService.getTotalCount("injury", 2022);
         if (data !== null) {
             setInjured(data);
         }

--- a/client/src/views/MemorialMainContent/MemorialInfomations/index.tsx
+++ b/client/src/views/MemorialMainContent/MemorialInfomations/index.tsx
@@ -10,8 +10,9 @@ import Container from "../../../components/common/Container";
 type MemorialInformationProps = {}
 
 const MemorialInformation: React.FC<MemorialInformationProps> = () => {
-
-    const statisticsTitle = `사회적 추모 아카이브 ${new Date(Date.now()).getFullYear()}`;
+    // NOTE: 현행화하기 전까지 2022년으로 설정합니다
+    // const statisticsTitle = `사회적 추모 아카이브 ${new Date(Date.now()).getFullYear()}`;
+    const statisticsTitle = `사회적 추모 아카이브 ${2022}`;
     const articlesTitle = "당신이 읽어야 할 산업재해 이야기";
     const dataTableTitle = "산업재해 노동자 목록";
 


### PR DESCRIPTION
### 개요

4월 마지막중 세계 노동자 추모의 날을 위해 프로젝트를 다듬습니다.
프론트 페이지 연도를 2022년으로 설정하고, 백엔드 서버를 연결합니다.

#### 참고사항

임시로 작업하고, 백엔드로 사용하는 서버 작업한 다음 통계 현행화 작업해야 합니다.
